### PR TITLE
ENG-5857: fix a typo in comments

### DIFF
--- a/1_managing_resources/create_datasource/main.go
+++ b/1_managing_resources/create_datasource/main.go
@@ -52,7 +52,7 @@ func main() {
 		Password: "example",
 		Database: "example",
 		// May be set to one of the ResourceIPAllocationMode constants to select between VNM,
-		// loopback, or default allocation. If not set, will be behave as if configured for
+		// loopback, or default allocation. If not set, will behave as if configured for
 		// 'default'.
 		// For more details on Virtual Networking Mode see documentation here:
 		// https://docs.strongdm.com/admin/clients/client-networking/virtual-networking-mode


### PR DESCRIPTION
Small typo fix in updated examples.