### PR TITLE
ENG-5904: fix broken sdk examples

### DIFF
--- a/6_managing_workflows/create_workflow/create_auto_grant_workflow/go.mod
+++ b/6_managing_workflows/create_workflow/create_auto_grant_workflow/go.mod
@@ -2,9 +2,10 @@ module sdk
 
 go 1.21
 
+require github.com/strongdm/strongdm-sdk-go/v15 v15.21.0
+
 require (
 	github.com/golang/protobuf v1.5.0 // indirect
-	github.com/strongdm/strongdm-sdk-go/v4 v4.8.0 // indirect
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a // indirect
 	golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a // indirect
 	golang.org/x/text v0.3.0 // indirect

--- a/6_managing_workflows/create_workflow/create_auto_grant_workflow/go.sum
+++ b/6_managing_workflows/create_workflow/create_auto_grant_workflow/go.sum
@@ -15,13 +15,12 @@ github.com/golang/protobuf v1.5.0 h1:LUVKkCeviFUMKqHa4tXIIij/lbhnMbP7Fn5wKdKkRh4
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/strongdm/strongdm-sdk-go/v4 v4.7.0 h1:s1BujyAN1h/d4CwSuKyWY5PITIe8uwtuqFolw2yUaUw=
-github.com/strongdm/strongdm-sdk-go/v4 v4.7.0/go.mod h1:PwM6F/mXGN7KsBc+4q1NPw+vpDp8uTVhrCdg7QWDiDg=
-github.com/strongdm/strongdm-sdk-go/v4 v4.8.0 h1:95WNVtoCoEBahnQ+ngFF3+YhacLVuhD46/Op06qkUJM=
-github.com/strongdm/strongdm-sdk-go/v4 v4.8.0/go.mod h1:PwM6F/mXGN7KsBc+4q1NPw+vpDp8uTVhrCdg7QWDiDg=
+github.com/strongdm/strongdm-sdk-go/v15 v15.21.0 h1:1ALebqY24OOdBoQzBkl/RqH4yG0b+b58DHswirpvbSk=
+github.com/strongdm/strongdm-sdk-go/v15 v15.21.0/go.mod h1:Uzy5vLqzmFeXRq0ap12t//PaRKQu92IJkv8snmG05wE=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -45,6 +44,7 @@ golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/6_managing_workflows/create_workflow/create_auto_grant_workflow/main.go
+++ b/6_managing_workflows/create_workflow/create_auto_grant_workflow/main.go
@@ -20,7 +20,7 @@ import (
 	"os"
 	"time"
 
-	sdm "github.com/strongdm/strongdm-sdk-go/v4"
+	sdm "github.com/strongdm/strongdm-sdk-go/v15"
 )
 
 func main() {
@@ -44,13 +44,23 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
+	// Create an automatic ApprovalWorkflow
+	approvalFlow := &sdm.ApprovalWorkflow{
+		Name:         "Auto Grant Example",
+		ApprovalMode: "automatic",
+	}
+	approvalResponse, err := client.ApprovalWorkflows().Create(ctx, approvalFlow)
+	if err != nil {
+		log.Fatalf("Could not create approval workflow: %v", err)
+	}
+
 	// Create an auto grant Workflow with initial Access Rule. Note that this
 	// workflow will be enabled.
 	workflow := &sdm.Workflow{
-		Name:        "Example Create Auto Grant Workflow",
-		Description: "Example Workflow Description",
-		AutoGrant:   true,
-		Enabled:     true,
+		Name:           "Example Create Auto Grant Workflow",
+		Description:    "Example Workflow Description",
+		ApprovalFlowID: approvalResponse.ApprovalWorkflow.ID,
+		Enabled:        true,
 		AccessRules: sdm.AccessRules{
 			sdm.AccessRule{
 				Tags: sdm.Tags{

--- a/6_managing_workflows/create_workflow_full_examples/create_auto_grant_workflow/go.mod
+++ b/6_managing_workflows/create_workflow_full_examples/create_auto_grant_workflow/go.mod
@@ -2,9 +2,10 @@ module sdk
 
 go 1.21
 
+require github.com/strongdm/strongdm-sdk-go/v15 v15.21.0
+
 require (
 	github.com/golang/protobuf v1.5.0 // indirect
-	github.com/strongdm/strongdm-sdk-go/v4 v4.8.0 // indirect
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a // indirect
 	golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a // indirect
 	golang.org/x/text v0.3.0 // indirect

--- a/6_managing_workflows/create_workflow_full_examples/create_auto_grant_workflow/go.sum
+++ b/6_managing_workflows/create_workflow_full_examples/create_auto_grant_workflow/go.sum
@@ -15,13 +15,12 @@ github.com/golang/protobuf v1.5.0 h1:LUVKkCeviFUMKqHa4tXIIij/lbhnMbP7Fn5wKdKkRh4
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/strongdm/strongdm-sdk-go/v4 v4.7.0 h1:s1BujyAN1h/d4CwSuKyWY5PITIe8uwtuqFolw2yUaUw=
-github.com/strongdm/strongdm-sdk-go/v4 v4.7.0/go.mod h1:PwM6F/mXGN7KsBc+4q1NPw+vpDp8uTVhrCdg7QWDiDg=
-github.com/strongdm/strongdm-sdk-go/v4 v4.8.0 h1:95WNVtoCoEBahnQ+ngFF3+YhacLVuhD46/Op06qkUJM=
-github.com/strongdm/strongdm-sdk-go/v4 v4.8.0/go.mod h1:PwM6F/mXGN7KsBc+4q1NPw+vpDp8uTVhrCdg7QWDiDg=
+github.com/strongdm/strongdm-sdk-go/v15 v15.21.0 h1:1ALebqY24OOdBoQzBkl/RqH4yG0b+b58DHswirpvbSk=
+github.com/strongdm/strongdm-sdk-go/v15 v15.21.0/go.mod h1:Uzy5vLqzmFeXRq0ap12t//PaRKQu92IJkv8snmG05wE=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -45,6 +44,7 @@ golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/6_managing_workflows/create_workflow_full_examples/create_auto_grant_workflow/main.go
+++ b/6_managing_workflows/create_workflow_full_examples/create_auto_grant_workflow/main.go
@@ -20,7 +20,7 @@ import (
 	"os"
 	"time"
 
-	sdm "github.com/strongdm/strongdm-sdk-go/v4"
+	sdm "github.com/strongdm/strongdm-sdk-go/v15"
 )
 
 func main() {
@@ -44,11 +44,21 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
+	// Create an automatic ApprovalWorkflow
+	approvalFlow := &sdm.ApprovalWorkflow{
+		Name:         "Auto Grant Example",
+		ApprovalMode: "automatic",
+	}
+	approvalResponse, err := client.ApprovalWorkflows().Create(ctx, approvalFlow)
+	if err != nil {
+		log.Fatalf("Could not create approval workflow: %v", err)
+	}
+
 	// Create an auto grant Workflow with initial Access Rule
 	workflow := &sdm.Workflow{
 		Name:        "Full Example Create Auto Grant Workflow",
 		Description: "Example Workflow Description",
-		AutoGrant:   true,
+		ApprovalFlowID: approvalResponse.ApprovalWorkflow.ID,
 		Enabled:     true,
 		AccessRules: sdm.AccessRules{
 			sdm.AccessRule{

--- a/6_managing_workflows/create_workflow_full_examples/create_manual_workflow/go.mod
+++ b/6_managing_workflows/create_workflow_full_examples/create_manual_workflow/go.mod
@@ -2,9 +2,10 @@ module sdk
 
 go 1.21
 
+require github.com/strongdm/strongdm-sdk-go/v15 v15.21.0
+
 require (
 	github.com/golang/protobuf v1.5.0 // indirect
-	github.com/strongdm/strongdm-sdk-go/v4 v4.8.0 // indirect
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a // indirect
 	golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a // indirect
 	golang.org/x/text v0.3.0 // indirect

--- a/6_managing_workflows/create_workflow_full_examples/create_manual_workflow/go.sum
+++ b/6_managing_workflows/create_workflow_full_examples/create_manual_workflow/go.sum
@@ -15,13 +15,12 @@ github.com/golang/protobuf v1.5.0 h1:LUVKkCeviFUMKqHa4tXIIij/lbhnMbP7Fn5wKdKkRh4
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/strongdm/strongdm-sdk-go/v4 v4.7.0 h1:s1BujyAN1h/d4CwSuKyWY5PITIe8uwtuqFolw2yUaUw=
-github.com/strongdm/strongdm-sdk-go/v4 v4.7.0/go.mod h1:PwM6F/mXGN7KsBc+4q1NPw+vpDp8uTVhrCdg7QWDiDg=
-github.com/strongdm/strongdm-sdk-go/v4 v4.8.0 h1:95WNVtoCoEBahnQ+ngFF3+YhacLVuhD46/Op06qkUJM=
-github.com/strongdm/strongdm-sdk-go/v4 v4.8.0/go.mod h1:PwM6F/mXGN7KsBc+4q1NPw+vpDp8uTVhrCdg7QWDiDg=
+github.com/strongdm/strongdm-sdk-go/v15 v15.21.0 h1:1ALebqY24OOdBoQzBkl/RqH4yG0b+b58DHswirpvbSk=
+github.com/strongdm/strongdm-sdk-go/v15 v15.21.0/go.mod h1:Uzy5vLqzmFeXRq0ap12t//PaRKQu92IJkv8snmG05wE=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -45,6 +44,7 @@ golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/6_managing_workflows/update_workflow/go.mod
+++ b/6_managing_workflows/update_workflow/go.mod
@@ -2,9 +2,10 @@ module sdk
 
 go 1.21
 
+require github.com/strongdm/strongdm-sdk-go/v15 v15.21.0
+
 require (
 	github.com/golang/protobuf v1.5.0 // indirect
-	github.com/strongdm/strongdm-sdk-go/v4 v4.8.0 // indirect
 	golang.org/x/net v0.0.0-20190311183353-d8887717615a // indirect
 	golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a // indirect
 	golang.org/x/text v0.3.0 // indirect

--- a/6_managing_workflows/update_workflow/go.sum
+++ b/6_managing_workflows/update_workflow/go.sum
@@ -15,13 +15,12 @@ github.com/golang/protobuf v1.5.0 h1:LUVKkCeviFUMKqHa4tXIIij/lbhnMbP7Fn5wKdKkRh4
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
-github.com/strongdm/strongdm-sdk-go/v4 v4.7.0 h1:s1BujyAN1h/d4CwSuKyWY5PITIe8uwtuqFolw2yUaUw=
-github.com/strongdm/strongdm-sdk-go/v4 v4.7.0/go.mod h1:PwM6F/mXGN7KsBc+4q1NPw+vpDp8uTVhrCdg7QWDiDg=
-github.com/strongdm/strongdm-sdk-go/v4 v4.8.0 h1:95WNVtoCoEBahnQ+ngFF3+YhacLVuhD46/Op06qkUJM=
-github.com/strongdm/strongdm-sdk-go/v4 v4.8.0/go.mod h1:PwM6F/mXGN7KsBc+4q1NPw+vpDp8uTVhrCdg7QWDiDg=
+github.com/strongdm/strongdm-sdk-go/v15 v15.21.0 h1:1ALebqY24OOdBoQzBkl/RqH4yG0b+b58DHswirpvbSk=
+github.com/strongdm/strongdm-sdk-go/v15 v15.21.0/go.mod h1:Uzy5vLqzmFeXRq0ap12t//PaRKQu92IJkv8snmG05wE=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -45,6 +44,7 @@ golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=

--- a/6_managing_workflows/update_workflow/main.go
+++ b/6_managing_workflows/update_workflow/main.go
@@ -20,7 +20,7 @@ import (
 	"os"
 	"time"
 
-	sdm "github.com/strongdm/strongdm-sdk-go/v4"
+	sdm "github.com/strongdm/strongdm-sdk-go/v15"
 )
 
 func main() {
@@ -93,23 +93,34 @@ func main() {
 	fmt.Println("Successfully update Workflow Weight.")
 	fmt.Println("\tNew Weight:", wf.Weight)
 
-	// Update Workflow AutoGrant
-	auto := wf.AutoGrant
-	wf.AutoGrant = !auto
+	// Create an automatic ApprovalWorkflow
+	approvalFlow := &sdm.ApprovalWorkflow{
+		Name:         "Auto Grant Example",
+		ApprovalMode: "automatic",
+	}
+	approvalResponse, err := client.ApprovalWorkflows().Create(ctx, approvalFlow)
+	if err != nil {
+		log.Fatalf("Could not create approval workflow: %v", err)
+	}
+
+	fmt.Println("Successfully create new ApprovalWorkflow.")
+	fmt.Println("\tApproval Flow ID:", approvalResponse.ApprovalWorkflow.ID)
+
+	// Update Workflow ApprovalFlow
+	wf.ApprovalFlowID = approvalResponse.ApprovalWorkflow.ID
 	updated, err = client.Workflows().Update(ctx, wf)
 	if err != nil {
 		log.Fatalf("Could not update workflow: %v", err)
 	}
 	wf = updated.Workflow
 
-	fmt.Println("Successfully update Workflow AutoGrant.")
-	fmt.Println("\tAutoGrant:", wf.AutoGrant)
+	fmt.Println("Successfully update Workflow ApprovalFlow.")
+	fmt.Println("\tNew ID:", wf.ApprovalFlowID)
 
 	// Update Workflow Enabled
 	// The requirements to enable a workflow are that the workflow must be either set
-	// up for with auto grant enabled or have one or more WorkflowApprovers created for
+	// up with an automatic grant enabled or have one or more WorkflowApprovers created for
 	// the workflow.
-	wf.AutoGrant = true
 	wf.Enabled = true
 	updated, err = client.Workflows().Update(ctx, wf)
 	if err != nil {


### PR DESCRIPTION
This change fixes workflow tests that were using out of date autogrant behavior.  These examples have been updated to use ApprovalWorkflows.

**QA**

All tests under section 6_managing_workflows now successfully run

Addresses ENG-5904